### PR TITLE
Gender correction of the word entity in French

### DIFF
--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -99,7 +99,7 @@ const editHandlers: EditHandlers = {
   },
   remove: {
     tooltip: {
-      text: "Cliquez sur un entité pour supprimer",
+      text: "Cliquez sur une entité pour supprimer",
     },
   },
 };


### PR DESCRIPTION
Correction of "un entité" to "une entité"