### PR TITLE
Add Persian language support to leaflet.draw.locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ L.drawLocal = locale
 | de   | German      |
 | en   | English     |
 | ar   | Arabic      |
+| fa   | Persian     |
 | fi   | Finnish     |
 | fr   | French      |
 | hu   | Hungarian   |

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import cs from "./locales/cs";
 import de from "./locales/de";
 import en from "./locales/en";
 import es from "./locales/es";
+import fa from "./locales/fa";
 import fi from "./locales/fi";
 import fr from "./locales/fr";
 import hu from "./locales/hu";
@@ -20,7 +21,7 @@ import zh from "./locales/zh";
 import tr from "./locales/tr";
 import ro from "./locales/ro";
 
-export const languages: Language[] = ["ar", "am", "cs", "de", "en", "es", "fi", "fr", "hu", "it", "ka", "nl", "no", "pl", "pt", "ru", "sk", "uk", "zh", "tr", "ro"];
+export const languages: Language[] = ["ar", "am", "cs", "de", "en", "es", "fa", "fi", "fr", "hu", "it", "ka", "nl", "no", "pl", "pt", "ru", "sk", "uk", "zh", "tr", "ro"];
 
 /**
  * Localization for Leaflet.draw, changing between languages is now effortless.
@@ -69,6 +70,12 @@ export const drawLocales = (language: Language): DrawLocal => {
     case "ar-eg":
     case "arabic": {
       locale = ar;
+      break;
+    }
+    case "fa":
+    case "fa-ir":
+    case "persian": {
+      locale = fa;
       break;
     }
     case "fi":

--- a/src/index.ts
+++ b/src/index.ts
@@ -233,6 +233,7 @@ export type Language =
   | "de" | "de-at" | "de-be" | "de-ch" | "de-de" | "de-li" | "de-lu" | "de-de.utf-8" | "german"
   | "en" | "en-us" | "en-us.utf-8" | "english" | "en-ca" | "en-gb"
   | "ar" | "ar-ae" | "english"
+  | "fa" | "fa-ir" | "persian"
   | "fi" | "fi-fi" | "fi-fi.utf-8" | "finnish"
   | "fr" | "fr-us" | "fr-us.utf-8" | "french" | "fr-ca"
   | "es" | "es-us" | "es-us.utf-8" | "spanish" | "es-ca"

--- a/src/locales/fa.ts
+++ b/src/locales/fa.ts
@@ -1,0 +1,116 @@
+import { DrawHandlers, DrawToolbar, EditHandlers, EditToolbar } from "../index";
+
+const drawToolbar: DrawToolbar = {
+	actions: {
+		title: 'لغو ترسیم',
+		text: 'لغو'
+	},
+	finish: {
+		title: 'پایان ترسیم',
+		text: 'پایان'
+	},
+	undo: {
+		title: 'حذف آخرین نقطه کشیده شده',
+		text: 'حذف آخرین نقطه'
+	},
+	buttons: {
+		polyline: 'ترسیم یک خط',
+		polygon: 'ترسیم زمین',
+		rectangle: 'ترسیم یک مربع',
+		circle: 'ترسیم یک دایره',
+		marker: 'نشانه گذاری',
+		circlemarker: 'یک نشانگر دایره ای بکشید'
+	}
+};
+
+const drawHandlers: DrawHandlers = {
+	circle: {
+		tooltip: {
+			start: 'کیلک و کشیدن برای رسم دایره.'
+		},
+		radius: 'شعاع'
+	},
+	circlemarker: {
+		tooltip: {
+			start: 'برای قرار دادن علامت روی نقشه کلیک کنید.'
+		}
+	},
+	marker: {
+		tooltip: {
+			start: 'روی نقشه کلیک کنید.'
+		}
+	},
+	polygon: {
+		tooltip: {
+			start: 'برای رسم چند ضلعی کلیک کنید.',
+			cont: 'برای ادامه ترسیم کلیک کنید.',
+			end: 'برای اتمام روی نقطه شروع کلیک کنید.'
+		}
+	},
+	polyline: {
+		error: '<strong>خطاء:</strong> لبه های شکل نمی توانند متقاطع شوند!',
+		tooltip: {
+			start: 'برای ترسیم خط کلیک کنید.',
+			cont: 'برای ادامه ترسیم کلیک کنید.',
+			end: 'برای اتمام روی نقطه شروع کلیک کنید.'
+		}
+	},
+	rectangle: {
+		tooltip: {
+			start: 'کیلک و کشیدن برای رسم دایره.'
+		}
+	},
+	simpleshape: {
+		tooltip: {
+			end: 'برای اتمام موس را رها کنید.'
+		}
+	}
+};
+
+const editToolbar: EditToolbar = {
+	actions: {
+		save: {
+			title: 'ذخیره تغییرات',
+			text: 'ذخیره'
+		},
+		cancel: {
+			title: 'لغو ویرایش، حذف همه تغییرات',
+			text: 'لغو'
+		},
+		clearAll: {
+			title: 'حذف تمام لایه ها',
+			text: 'پاک سازی همه'
+		}
+	},
+	buttons: {
+		edit: 'ویرایش لایه ها',
+		editDisabled: 'لایه ای برای ویرایش نیست',
+		remove: 'حذف لایه ها',
+		removeDisabled: 'لایه ای برای حذف نیست'
+	}
+};
+
+const editHandlers: EditHandlers = {
+  edit: {
+		tooltip: {
+			text: 'برای ویرایش، نشانگرها را بکشید.',
+			subtext: 'برای لغو تغییرات روی "لغو" کلیک کنید.'
+		}
+	},
+	remove: {
+		tooltip: {
+			text: 'برای حذف روی یک ویژگی کلیک کنید.'
+		}
+	}
+};
+
+export default {
+  draw: {
+    toolbar: drawToolbar,
+    handlers: drawHandlers,
+  },
+  edit: {
+    toolbar: editToolbar,
+    handlers: editHandlers,
+  },
+};

--- a/src/locales/fa.ts
+++ b/src/locales/fa.ts
@@ -3,15 +3,15 @@ import { DrawHandlers, DrawToolbar, EditHandlers, EditToolbar } from "../index";
 const drawToolbar: DrawToolbar = {
 	actions: {
 		title: 'لغو ترسیم',
-		text: 'لغو'
+		text: 'لغو',
 	},
 	finish: {
 		title: 'پایان ترسیم',
-		text: 'پایان'
+		text: 'پایان',
 	},
 	undo: {
 		title: 'حذف آخرین نقطه کشیده شده',
-		text: 'حذف آخرین نقطه'
+		text: 'حذف آخرین نقطه',
 	},
 	buttons: {
 		polyline: 'ترسیم یک خط',
@@ -20,7 +20,7 @@ const drawToolbar: DrawToolbar = {
 		circle: 'ترسیم یک دایره',
 		marker: 'نشانه گذاری',
 		circlemarker: 'یک نشانگر دایره ای بکشید'
-	}
+	},
 };
 
 const drawHandlers: DrawHandlers = {
@@ -33,19 +33,19 @@ const drawHandlers: DrawHandlers = {
 	circlemarker: {
 		tooltip: {
 			start: 'برای قرار دادن علامت روی نقشه کلیک کنید.'
-		}
+		},
 	},
 	marker: {
 		tooltip: {
 			start: 'روی نقشه کلیک کنید.'
-		}
+		},
 	},
 	polygon: {
 		tooltip: {
 			start: 'برای رسم چند ضلعی کلیک کنید.',
 			cont: 'برای ادامه ترسیم کلیک کنید.',
 			end: 'برای اتمام روی نقطه شروع کلیک کنید.'
-		}
+		},
 	},
 	polyline: {
 		error: '<strong>خطاء:</strong> لبه های شکل نمی توانند متقاطع شوند!',
@@ -53,18 +53,18 @@ const drawHandlers: DrawHandlers = {
 			start: 'برای ترسیم خط کلیک کنید.',
 			cont: 'برای ادامه ترسیم کلیک کنید.',
 			end: 'برای اتمام روی نقطه شروع کلیک کنید.'
-		}
+		},
 	},
 	rectangle: {
 		tooltip: {
 			start: 'کیلک و کشیدن برای رسم دایره.'
-		}
+		},
 	},
 	simpleshape: {
 		tooltip: {
 			end: 'برای اتمام موس را رها کنید.'
-		}
-	}
+		},
+	},
 };
 
 const editToolbar: EditToolbar = {
@@ -80,14 +80,14 @@ const editToolbar: EditToolbar = {
 		clearAll: {
 			title: 'حذف تمام لایه ها',
 			text: 'پاک سازی همه'
-		}
+		},
 	},
 	buttons: {
 		edit: 'ویرایش لایه ها',
 		editDisabled: 'لایه ای برای ویرایش نیست',
 		remove: 'حذف لایه ها',
 		removeDisabled: 'لایه ای برای حذف نیست'
-	}
+	},
 };
 
 const editHandlers: EditHandlers = {
@@ -95,13 +95,13 @@ const editHandlers: EditHandlers = {
 		tooltip: {
 			text: 'برای ویرایش، نشانگرها را بکشید.',
 			subtext: 'برای لغو تغییرات روی "لغو" کلیک کنید.'
-		}
+		},
 	},
 	remove: {
 		tooltip: {
 			text: 'برای حذف روی یک ویژگی کلیک کنید.'
-		}
-	}
+		},
+	},
 };
 
 export default {


### PR DESCRIPTION
In this PR, I have added Persian language support to the leaflet.draw.locales package. This will enable users to utilize the package in Persian-speaking regions and enhance the localization capabilities of the library.

Changes Made:

Created a new file fa.ts in the locales directory
Added translations for all the necessary strings in Persian
Updated the index.js file to include the Persian language file
Testing Done:

Tested the changes locally by setting the language to Persian and verifying the correctness of the translations
Checked that the package functions as expected with the new Persian language support
Contributor's Note:
I am a native Persian speaker and have experience with localization and translation work. I have carefully reviewed and tested the changes to ensure accuracy and compatibility.

Please let me know if any further modifications or improvements are required. I'm open to feedback and eager to collaborate on incorporating Persian language support into the main repository.

Thank you for considering this contribution.